### PR TITLE
Use gitmodules instead of parsing github html (fixes #6).

### DIFF
--- a/addons_installer.FCMacro
+++ b/addons_installer.FCMacro
@@ -45,6 +45,7 @@ installed.
 
 from PySide import QtCore, QtGui
 import FreeCAD,urllib2,re,os,shutil
+import ConfigParser, StringIO
 
 
 def symlink(source, link_name):
@@ -192,18 +193,22 @@ class UpdateWorker(QtCore.QThread):
     def run(self):
         "populates the list of addons"
         self.progressbar_show.emit(True)
-        u = urllib2.urlopen("https://github.com/FreeCAD/FreeCAD-addons")
-        p = u.read()
+        u = urllib2.urlopen("https://raw.githubusercontent.com/FreeCAD/FreeCAD-addons/master/.gitmodules")
+        # Use config parser to read the ini-ish format file
+        # Need to mangle slightly as ConfigParser (pre-python-3.2)
+        # doesn't accept leading whitespace
+        c = ConfigParser.ConfigParser()
+        p = "\n".join([i.strip() for i in u.readlines()])
         u.close()
-        p = p.replace("\n"," ")
-        p = re.findall("octicon-file-submodule(.*?)message",p)
+        buf = StringIO.StringIO(p)
+        c.readfp(buf)
+        repos = []
         basedir = FreeCAD.ConfigGet("UserAppData")
         moddir = basedir + os.sep + "Mod"
-        repos = []
-        for l in p:
-            name = re.findall("data-skip-pjax=\"true\">(.*?)<",l)[0]
+        for section in c.sections():
+            name = c.get(section, 'path')
             self.info_label.emit(name)
-            url = re.findall("title=\"(.*?) @",l)[0]
+            url = c.get(section, 'url')
             addondir = moddir + os.sep + name
             if not os.path.exists(addondir):
                 state = 0


### PR DESCRIPTION
Having dug into the problem of #6 a little more, it looks like it is due to the way the code is trying to parse github's html code.  Presumably github have changed something in the way that the html code is generated and it has broken the parser.

As an alternative, it looks to me as if we can get all of the required information by reading the raw .gitmodules file and hence I've implemented a simple parser for that.