### PR TITLE
Update to handle submodules in workbenches.

### DIFF
--- a/addons_installer.FCMacro
+++ b/addons_installer.FCMacro
@@ -516,12 +516,21 @@ class InstallWorker(QtCore.QThread):
             if git:
                 repo = git.Git(clonedir)
                 answer = repo.pull()
+
+                # Update the submodules for this repository
+                repo_sms = git.Repo(clonedir)
+                for submodule in repo_sms.submodules:
+                    submodule.update(init=True, recursive=True)
             else:
                 answer = self.download(self.repos[self.idx][1],clonedir)
         else:
             if git:
                 self.info_label.emit("Cloning module...")
                 repo = git.Repo.clone_from(self.repos[self.idx][1], clonedir, branch='master')
+
+                # Make sure to clone all the submodules as well
+                if repo.submodules:
+                    repo.submodule_update(recursive=True)
             else:
                 self.info_label.emit("Downloading module...")
                 self.download(self.repos[self.idx][1],clonedir)


### PR DESCRIPTION
[My workbench](https://github.com/jmwright/cadquery-freecad-module) now has the core library set up as a submodule. This was done because copying the library directory in manually or using a subtree was causing maintenance problems. This PR adds submodule support to the macro to handle workbench repo structures like mine.