### PR TITLE
Add FreeCAD YAML Workspace

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -142,3 +142,7 @@
 [submodule "Render"]
 	path = Render
 	url = https://github.com/FreeCAD/FreeCAD-render.git
+[submodule "yaml-workspace"]
+	path = yaml-workspace
+	url = https://github.com/Mambix/FreeCAD-yaml-workspace.git
+	branch = master

--- a/FreeCAD-Addon-Details.md
+++ b/FreeCAD-Addon-Details.md
@@ -292,3 +292,11 @@ A Timber module for FreeCAD
 
 #### [workfeature](https://github.com/Rentlau/WorkFeature/)
 Tool utility to create Points (mid points, center of circle, center of object(s)...), Axes (from 2 points, Normal of a plane...), Planes (from 3 points, from one axis and a point...) and many other useful features to facilitate the creation of your project. This utility is up next in the combo view with "Work Features" label.
+
+---
+
+#### [yaml-workspace](https://github.com/Mambix/FreeCAD-yaml-workspace/)
+This tool allows you to create YAML configuration files for easy importing of files. If your import files change often and you use FreeCAD to check how parts fit together this makes it much easier and faster to check designs.
+
+[![IMAGE ALT TEXT](http://img.youtube.com/vi/PO6Uz16cdP8/0.jpg)](http://www.youtube.com/watch?v=PO6Uz16cdP8 "YAML Workspace")  
+


### PR DESCRIPTION
By @luzpaz suggestion I would like to add YAML workspace to this list.

It allows users to easily open multiple files and position them with the help of a simple YAML configuration file.

YAML config file used in the youtube video for demonstration:
```YAML
settings:
  subDirectory: stl
import:
  EATX:
    EATX:
      files:
        - BOTTOM.stl
        - LEFT.stl
      FRONT.stl:
        color: [.0, .0, 1.0]
        placement: [.0, 50.0, .0]
      BACK.stl:
        color: [.0, .0, 1.0]
        transparency: 50
      TOP.stl:
        color: green
        transparency: 50
        placement: [.0, .0, -5.0]
      RIGHT.stl:
        color: red
        transparency: 50
```

It crates a new document and imports six STL files. Some objects are left untouched, while others get moved. apply transparency and colour.