### PR TITLE
Fix #61 (insufficient rights to create symlink)

### DIFF
--- a/addons_installer.FCMacro
+++ b/addons_installer.FCMacro
@@ -65,6 +65,9 @@ def symlink(source, link_name):
             csl.argtypes = (ctypes.c_wchar_p, ctypes.c_wchar_p, ctypes.c_uint32)
             csl.restype = ctypes.c_ubyte
             flags = 1 if os.path.isdir(source) else 0
+            # set the SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE flag 
+            # (see https://blogs.windows.com/buildingapps/2016/12/02/symlinks-windows-10/#joC5tFKhdXs2gGml.97)
+            flags += 2
             if csl(link_name, source, flags) == 0:
                 raise ctypes.WinError()
 

--- a/addons_installer.FCMacro
+++ b/addons_installer.FCMacro
@@ -67,7 +67,7 @@ def symlink(source, link_name):
             flags = 1 if os.path.isdir(source) else 0
             # set the SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE flag 
             # (see https://blogs.windows.com/buildingapps/2016/12/02/symlinks-windows-10/#joC5tFKhdXs2gGml.97)
-            flags += 2
+            flags |= 2
             if csl(link_name, source, flags) == 0:
                 raise ctypes.WinError()
 


### PR DESCRIPTION
On Windows 10, symlink creation is not allowed unless the process runs with elevated rights. 

As per https://blogs.windows.com/buildingapps/2016/12/02/symlinks-windows-10/#joC5tFKhdXs2gGml.97, starting with Windows 10 Insiders build 14972, symlinks can be created without needing to elevate the console as administrator.

To use this functionality, 0x2 needs to be set in the flags argument for the CreateSymbolicLinkW() call. This fixes #61 .

A separate patch for the integrated AddOnManager is forthcoming.