### PR TITLE
EM Workbench addition

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -185,3 +185,6 @@
 [submodule "SlopedPlanesMacro"]
 	path = SlopedPlanesMacro
 	url = https://github.com/luzpaz/SlopedPlanesMacro.git
+[submodule "EM"]
+	path = EM
+	url = https://github.com/ediloren/EM-Workbench-for-FreeCAD

--- a/FreeCAD-Addon-Details.md
+++ b/FreeCAD-Addon-Details.md
@@ -77,6 +77,20 @@ Create container object to hold custom properties.
 </details>
 
 ---
+
+#### [ElectroMagnetic](https://github.com/ediloren/EM-Workbench-for-FreeCAD/edit/master/README.md)
+ElectroMagnetic Workbench for [FastFieldSolvers](https://www.fastfieldsolvers.com) free tools
+<details>
+  <summary>Details...</summary>
+This project is dedicated to building an ElectroMagnetic workbench for [FreeCAD](https://www.freecadweb.org). FreeCAD is used as pre-processor interfacing to the open source electromagnetic field solvers [FastHenry](https://www.fastfieldsolvers.com/fasthenry2.htm) and [FasterCap](https://www.fastfieldsolvers.com/fastercap.htm).
+
+At present, the workbench supports:
+
+- [FastHenry](https://www.fastfieldsolvers.com/fasthenry2.htm) inductance solver: ongoing development including GUI support
+- [FasterCap](https://www.fastfieldsolvers.com/fastercap.htm) capacitance solver: ongoing development, today at the stage of Python macro only, for creating an input file
+</details>
+
+---
 #### [FCGear](https://github.com/looooo/FCGear/)
 
 <details>


### PR DESCRIPTION
Hi, I've added the EM Workbench in the addons (as discussed in the FreeCAD forum under FEM, see https://forum.freecadweb.org/viewtopic.php?f=18&t=31920) 

I will also now post under Announcements in the Forum to advertise the availability of the Workbench.

Wiki addon pages are updated:

https://freecadweb.org/wiki/External_workbenches
https://www.freecadweb.org/wiki/Template:DevWorkbenches

Documentation is complete under 

https://www.freecadweb.org/wiki/EM_Workbench

Thanks for pulling!

Enrico

