### PR TITLE
Proposal for an add-on to create interlocking parts.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -191,3 +191,6 @@
 [submodule "EM"]
 	path = EM
 	url = https://github.com/ediloren/EM-Workbench-for-FreeCAD
+[submodule "LCInterlocking"]
+	path = LCInterlocking
+	url = https://github.com/execuc/LCInterlocking	

--- a/FreeCAD-Addon-Details.md
+++ b/FreeCAD-Addon-Details.md
@@ -117,6 +117,16 @@ Launcher widget for FreeCAD
 
 ---
 
+#### [LCInterlocking](https://github.com/execuc/LCInterlocking)
+Interlocking module for FreeCAD
+
+<details>
+  <summary>Details...</summary>
+  This module is used to create interlocking cut parts from 3D to 2D SVG. It was created for laser cutting but can work with CNC router.
+</details>
+
+---
+
 #### [NavigationIndicator](https://github.com/triplus/NavigationIndicator/)
 Navigation indicator for FreeCAD
 


### PR DESCRIPTION
This FreeCAD module is used to create interlocking cut parts from 3D to 2D SVG. It was created for laser cutting but can work with CNC router.

GitHub: https://github.com/execuc/LCInterlocking
FreeCAD forum: https://forum.freecadweb.org/viewtopic.php?f=9&t=35635