### PR TITLE
added slic3r tools

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -200,3 +200,6 @@
 [submodule "Ship"]
 	path = Ship
 	url = https://github.com/FreeCAD/freecad.ship
+[submodule "slic3r-tools"]
+	path = slic3r-tools
+	url = https://github.com/limikael/freecad-slic3r-tools


### PR DESCRIPTION
This adds a workbench for using FreeCAD and Slic3r for 3D printing, without having to manually go through the many clicks of exporting and running Slic3r manually.

Here is a discussion on the forum:

https://forum.freecadweb.org/viewtopic.php?f=9&t=36342