### PR TITLE
Add OSE3dPrinter workbench sub-module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -245,3 +245,6 @@
 [submodule "ModernUI"]
 	path = ModernUI
 	url = https://github.com/HakanSeven12/Modern-UI.git
+[submodule "OSE3dPrinter"]
+	path = OSE3dPrinter
+	url = https://github.com/gbroques/ose-3d-printer-workbench/


### PR DESCRIPTION
@luzpaz 

* [x] Announce your Workbench on the FreeCAD Forums
    * Announced here: https://forum.freecadweb.org/viewtopic.php?f=9&t=45462

* [x] ~~Create a dedicated page for your workbench on the FreeCAD wiki (don't forget to add [[Category:Addons]] to it)~~ (skipping this as I don't want to maintain that Wiki page in addition to my README and custom docs website) + add it to https://freecadweb.org/wiki/External_workbenches

* [x] Create an entry on https://www.freecadweb.org/wiki/Template:DevWorkbenches

* [x] Tag (AKA 'label) your Github repo with the following: freecad, addons, and workbench

* [x] Make sure you have a simple SVG logo of your workbench (no larger than 10kb) that can be used to represent it in the Addon Manager dialog. The PR to FreeCAD master must include the:

    * 5a. logo which needs to be added to FreeCAD/src/Mod/AddonManger/Resources/icons in the following format: <WorkbenchName>_workbench_icon.svg.

    * 5b. path to said above icon needs to be added to FreeCAD/src/Mod/AddonManger/Resources/AddonManager.qrc

    * See https://github.com/FreeCAD/FreeCAD/pull/3379

* [x] Please structure the README.md file in a way that makes it easy to understand while reading from the Addon Manager dialog. Example: SheetMetal Workbench
Note the use of: screenshots, screencasts, mentioning of Licence, Changelog etc...