### PR TITLE
Add addon flags file

### DIFF
--- a/addonflags.json
+++ b/addonflags.json
@@ -1,0 +1,22 @@
+{
+    "obsolete" : {
+        "name": "Obsolete",
+        "Mod": [
+            "assembly2",
+            "drawing_dimensioning",
+            "cura_engine"
+        ]
+    },
+    "py2only" : {
+        "name": "Python 2 Only",
+        "Mod": [
+            "geodata",
+            "GDT",
+            "timber",
+            "flamingo",
+            "reconstruction",
+            "animation"
+        ]
+    }
+
+}


### PR DESCRIPTION
Add addonflags.json file for marking addons.
This would allow to keep track of obsolete and python2 addons from this repo instead of having these lists [hardcoded](https://github.com/FreeCAD/FreeCAD/blob/master/src/Mod/AddonManager/addonmanager_workers.py#L43-L60). For more information check out [this forum page](https://forum.freecadweb.org/viewtopic.php?f=10&t=50265).
