### PR TITLE
Adding FEM_FrontISTR workbench

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -100,6 +100,9 @@
 [submodule "fcgear"]
 	path = FCGear
 	url = https://github.com/looooo/FCGear.git
+[submodule "FEM_FrontISTR"]
+	path = FEM_FrontISTR
+	url = https://github.com/FrontISTR/FEM_FrontISTR.git
 [submodule "flamingo"]
 	path = flamingo
 	url = https://github.com/oddtopus/flamingo.git


### PR DESCRIPTION
Adding a new FEM workbench for FreeCAD 0.19+.

- git repository: https://github.com/FrontISTR/FEM_FrontISTR
  - set freecad, addons, and workbench tags
- forum: https://forum.freecadweb.org/viewtopic.php?t=58019
- created an entry on https://wiki.freecadweb.org/External_workbenches
- wiki pages: https://wiki.freecadweb.org/FEM_FrontISTR_Workbench