### PR TITLE
Addon-manager: pyrate: changed repo url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -222,7 +222,7 @@
 	url = https://github.com/eddyverl/FreeCAD-Pyramids-and-Polyhedrons.git
 [submodule "pyrate"]
 	path = pyrate
-	url = https://github.com/mess42/pyrate.git
+	url = https://salsa.debian.org/mess42/pyrate.git
 [submodule "reconstruction"]
 	path = reconstruction
 	url = https://github.com/microelly2/reconstruction.git


### PR DESCRIPTION
Hey @luzpaz and @yorikvanhavre 

I changed the repo url of pyrate, since we moved to salsa.debian.org. I hope that editing the .gitmodules file directly is the correct way to do this. If this is not the case, please feel free to reject the PR and I will perform the changes in an appropriate manner. (But you have to tell me, how to do it :-))

Best wishes
Johannes