### PR TITLE
Add VendorParts workbench

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -286,6 +286,9 @@
 [submodule "trails"]
 	path = trails
 	url = https://github.com/joelgraff/freecad.trails
+[submodule "VendorParts"]
+	path = VendorParts
+	url = https://github.com/alexneufeld/FreeCAD_vendor_parts.git
 [submodule "WebTools"]
 	path = WebTools
 	url = https://github.com/yorikvanhavre/WebTools.git
@@ -298,3 +301,4 @@
 [submodule "yaml-workspace"]
 	path = yaml-workspace
 	url = https://github.com/Mambix/FreeCAD-yaml-workspace.git
+


### PR DESCRIPTION
This small addon is in a usable state, and it was requested that it be added to the Addon Manager.
I'm working on the relevant wiki pages and PR to the main FC repo, per instructions in this repository's README file.

[forum thread](https://forum.freecadweb.org/viewtopic.php?f=8&t=62131) for the addon
