### PR TITLE
Switch URL for CfdOF to gitlab

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -64,7 +64,7 @@
 	url = https://github.com/jmwright/cadquery-freecad-module.git
 [submodule "CfdOF"]
 	path = CfdOF
-	url = https://github.com/jaheyns/CfdOF.git
+	url = https://gitlab.com/opensimproject/CfdOF
 [submodule "Cfd"]
 	path = Cfd
 	url = https://github.com/qingfengxia/Cfd.git


### PR DESCRIPTION
I believe that the actual canonical development location for CfdOF is the Gitlab URL, with GitHub serving only as a mirror -- since the package.xml file specifies the Gitlab location, and both 0.19.4 and 0.20 support Gitlab repos now, I suggest migrating to the official URL now.