### PR TITLE
Update freecad.gears branch to develop

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -124,6 +124,7 @@
 [submodule "fcgear"]
 	path = freecad.gears
 	url = https://github.com/looooo/freecad.gears
+	branch = develop
 [submodule "FeedsAndSpeeds"]
 	path = FeedsAndSpeeds
 	url = https://github.com/dubstar-04/FeedsAndSpeeds.git


### PR DESCRIPTION
The package.xml file in freecad.gears specifies "develop" as the branch to be used -- the Addons repo here should match that. So either the package.xml file needs to be set to `master`, or FreeCAD-addons needs to be set to use `develop`. @looooo can you clarify?