### PR TITLE
Adds Awkward Array to ALLOWED_PYTHON_PACKAGES.txt

### DIFF
--- a/ALLOWED_PYTHON_PACKAGES.txt
+++ b/ALLOWED_PYTHON_PACKAGES.txt
@@ -52,3 +52,4 @@ xlrd
 xlutils
 xlwt
 PyYAML
+awkward


### PR DESCRIPTION
Could you please add Awkward Array to the ALLOWED_PYTHON_PACKAGES.txt. I need this package for my new workbench [FreeCAD Nodes](https://github.com/j8sr0230/fc_nodes). Awkward Array is a library for nested, variable-sized data, including arbitrary-length lists, records, mixed types, and missing data, using NumPy-like idioms.

![Unbenannt](https://user-images.githubusercontent.com/39261150/198572335-9dcf6425-af50-49ea-b66b-f09d183f7d13.PNG)
