### PR TITLE
Move CfdOF module back to github project

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -68,7 +68,7 @@
 	url = https://github.com/jmwright/cadquery-freecad-module.git
 [submodule "CfdOF"]
 	path = CfdOF
-	url = https://gitlab.com/opensimproject/CfdOF
+	url = https://github.com/jaheyns/CfdOF.git
 [submodule "Cfd"]
 	path = Cfd
 	url = https://github.com/qingfengxia/Cfd.git


### PR DESCRIPTION
We would like to please move the CfdOF module back to point at the github mirror of the project. 

Some time ago, we started to transition the project across to gitlab (see #171, #223), but we have decided to abandon that now as the github one has become quite entrenched and the majority of activity remains there.

Thanks.