### PR TITLE
add Better Tool Library addon to .submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -47,6 +47,9 @@
 	path = Beltrami
 	url = https://github.com/Simturb/Beltrami
 	branch = main
+[submodule "btl"]
+	path = btl
+	url = https://github.com/knipknap/better-tool-library
 [submodule "BIMBots"]
 	path = BIMBots
 	url = https://github.com/opensourceBIM/BIMbots-FreeCAD


### PR DESCRIPTION
This PR is for my new addon [Better Tool Library](https://github.com/knipknap/better-tool-library/).
As per the instructions, I also requested a Wiki account on the forum to add the addon to the Wiki.