### PR TITLE
Add pyjwt and tzlocal to ALLOWED_PYTHON_PACKAGES

### DIFF
--- a/ALLOWED_PYTHON_PACKAGES.txt
+++ b/ALLOWED_PYTHON_PACKAGES.txt
@@ -44,6 +44,7 @@ py-slvs
 pycollada
 pydocx
 pygit2
+pyjwt
 pyoptools
 pynastran
 qtrangeslider
@@ -53,6 +54,7 @@ rhino3dm
 scikit-image
 scipy
 trimesh
+tzlocal
 xlrd
 xlutils
 xlwt


### PR DESCRIPTION
Both python libraries are useful to the `Ondsel-Lens` workbench.

The `pyjwt` library is for JSON Web Tokens, a mechanism used as part of online authentication security.

The `tzlocal` library is for getting the users local timezone information from the OS in a cross-platform manner.