### PR TITLE
Add the OSH Automated Documentation workbench

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -406,3 +406,6 @@
 [submodule "PieMenu"]
 	path = PieMenu
 	url = https://github.com/Grubuntu/PieMenu.git
+[submodule "osh-autodoc-workbench"]
+	path = osh-autodoc-workbench
+	url = https://codeberg.org/osh-autodoc/osh-autodoc-workbench.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -409,3 +409,4 @@
 [submodule "osh-autodoc-workbench"]
 	path = osh-autodoc-workbench
 	url = https://codeberg.org/osh-autodoc/osh-autodoc-workbench.git
+	branch = main


### PR DESCRIPTION
Add the OSH Automated Documentation workbench as a git submodule.

- [ ] Announce it on the forum: In principle done, but as soon as it is available in the Addon Manager, I will update that post.
- [x] Add a dedicated page on the wiki
- [x] Label the repo: not possible in Codeberg
- [x] logo
- [x] structure README
- [x] package.xml