### PR TITLE
added Bill of Materials workbench to .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -410,3 +410,7 @@
 	path = osh-autodoc-workbench
 	url = https://codeberg.org/osh-autodoc/osh-autodoc-workbench.git
 	branch = main
+[submodule "BillOfMaterials"]
+	path = BillOfMaterials
+	url = https://github.com/APEbbers/BillOfMaterials-WB.git
+        branch = main 

--- a/.gitmodules
+++ b/.gitmodules
@@ -373,6 +373,7 @@
 [submodule "TitleBlock"]
 	path = TitleBlock
 	url = https://github.com/APEbbers/TitleBlock-WB.git
+        branch = main 
 [submodule "timber"]
 	path = timber
 	url = https://github.com/wood-galaxy/FreeCAD-Timber.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -378,6 +378,9 @@
 [submodule "ThreadProfile"]
 	path = ThreadProfile
 	url = https://github.com/mwganson/ThreadProfile.git
+[submodule "TitleBlock"]
+	path = TitleBlock
+	url = https://github.com/APEbbers/TitleBlock-WB.git
 [submodule "timber"]
 	path = timber
 	url = https://github.com/wood-galaxy/FreeCAD-Timber.git


### PR DESCRIPTION
This is a workbench to create Bill of Materials with support for different types of assemblies.
Currently this workbench works with:
- a2plus
- Assembly 3
- Assembly 4
- internal assembly workbench (in progress because this wb is still under development)
- AppLink
- AppPart

I'm still working on this workbench, but i believe it is now in a state that it can be usefull already.
The support for the following assemblies, workbenches and futures are planned for the future:
- support for the Arch WB
- support for multi-body parts (Part WB)
- One function to support a mixed structure of all assembly workbenches
- A function to add the BoM to a TechDraw page template
- Mass calculation based on shape and material