### PR TITLE
Added "streamdeck" Python module

### DIFF
--- a/ALLOWED_PYTHON_PACKAGES.txt
+++ b/ALLOWED_PYTHON_PACKAGES.txt
@@ -54,6 +54,7 @@ rhino3dm
 scikit-image
 scikit-learn
 scipy
+streamdeck
 trimesh
 tzlocal
 xlrd


### PR DESCRIPTION
This module is used by the [Stream Deck Addon](https://github.com/Giraut/freecad_streamdeck_addon). Without the module being listed in the allowed Python packages, FreeCAD forces the user to install it manually when installing the Stream Deck Addon from the addon manager.