### PR TITLE
Remove OpenDark from .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -325,10 +325,6 @@
 	path = Ondsel-Lens
 	url = https://github.com/ondsel-Development/ondsel-lens
 	branch=master
-[submodule "OpenDark"]
-	path = OpenDark
-	url = https://github.com/obelisk79/OpenDark
-	branch = main
 [submodule "OpenTheme"]
 	path = OpenTheme
 	url = https://github.com/obelisk79/OpenTheme


### PR DESCRIPTION
OpenDark has been archived and is now developed under OpenTheme