### PR TITLE
Update ALLOWED_PYTHON_PACKAGES.txt, add protobuf

### DIFF
--- a/ALLOWED_PYTHON_PACKAGES.txt
+++ b/ALLOWED_PYTHON_PACKAGES.txt
@@ -42,6 +42,7 @@ openpyxl
 pandas
 pillow
 ply
+protobuf
 py-slvs
 pycollada
 pydocx


### PR DESCRIPTION
We need protobuf dependency for Taack PLM to work correctly. Protobuf allows to pack data in a binary format, but in a language and platform agnostic maner.