### PR TITLE
adding frameforge

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -533,3 +533,6 @@
 	path = BillOfMaterials
 	url = https://github.com/APEbbers/BillOfMaterials-WB
         branch = main 
+[submodule "FrameForge"]
+	path = FrameForge
+	url = https://github.com/lukh/frameforge


### PR DESCRIPTION
Adding Frameforge to Addon Manager: 
FrameForge is dedicated for creating Frames and Beams, and apply operations (miter cuts, trim cuts) on theses profiles.

I missed the WIKI add to 
https://wiki.freecad.org/External_workbenches

Because I don't know how to add translations