### PR TITLE
Fix SearchBar reference

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -467,7 +467,7 @@
     branch = master
 [submodule "SearchBar"]
     path = SearchBar
-	url = https://github.com/APEbbers/SearchBar
+    url = https://github.com/APEbbers/SearchBar
     branch = main
 [submodule "SelectorToolbar"]
     path = SelectorToolbar


### PR DESCRIPTION
Searching for "SearchBar still shows the SuzanneSoy repo. Does the new repo appears on your end?

```shell
git rm SearchBar
git submodule add -b main https://github.com/APEbbers/SearchBar SearchBar
```
Fix #334 
