### PR TITLE
ALLOWED_PYTHON_PACKAGES for fcVM-workbench

### DIFF
--- a/ALLOWED_PYTHON_PACKAGES.txt
+++ b/ALLOWED_PYTHON_PACKAGES.txt
@@ -31,6 +31,7 @@ ifcopenshell
 lxml
 markdown
 matplotlib
+meshio
 msgpack
 networkx
 nine
@@ -55,12 +56,14 @@ PyOpenGL
 pyopenxr
 pyoptools
 pynastran
+pyvista
 qtrangeslider
 qtpy
 requests
 rhino3dm
 scikit-image
 scikit-learn
+scikit-sparse
 scipy
 streamdeck
 trimesh


### PR DESCRIPTION
Added meshio, pyvista, scikit-sparse

Ref: https://github.com/HarryvL/fcVM-workbench/issues/4