### PR TITLE
Add the shapely package for the Rocket WB

### DIFF
--- a/ALLOWED_PYTHON_PACKAGES.txt
+++ b/ALLOWED_PYTHON_PACKAGES.txt
@@ -1,11 +1,11 @@
 # This file lists the Python packages that the Addon Manager allows to be installed
-# automatically via pip. To request that a package be added to this list, submit a 
-# pull request to the FreeCAD-addons git repository with the requested package added. 
-# Only packages in this list will be processed from the package.xml, metadata.txt and 
-# requirements.txt files specified by an Addon. A remote version of this file 
+# automatically via pip. To request that a package be added to this list, submit a
+# pull request to the FreeCAD-addons git repository with the requested package added.
+# Only packages in this list will be processed from the package.xml, metadata.txt and
+# requirements.txt files specified by an Addon. A remote version of this file
 # overrides the content of the locally-installed copy.
 
-# Note that this is NOT a requirements.txt-format file, no version information may be 
+# Note that this is NOT a requirements.txt-format file, no version information may be
 # specified, and no wildcards are supported.
 
 # Allow these packages to be installed:
@@ -61,6 +61,7 @@ qtrangeslider
 qtpy
 requests
 rhino3dm
+shapely
 scikit-image
 scikit-learn
 scikit-sparse


### PR DESCRIPTION
The shapely package is used by the Rocket WB to calculate the area of an .STL when projected on to a plane. This is necessary for calculating the Coefficient of Drag (CD) and for correctly sizing the virtual wind tunnels used in CFD studies.