### PR TITLE
[ Fix ] Dependency ( ETabs-API ) Typo

### DIFF
--- a/ALLOWED_PYTHON_PACKAGES.txt
+++ b/ALLOWED_PYTHON_PACKAGES.txt
@@ -26,7 +26,7 @@ charset-normalizer
 comtypes
 distro
 docutils
-etabs_api
+etabs-api
 ezdxf
 geomdl
 gmsh


### PR DESCRIPTION
`etabs_api` is actually [`etabs-api`](https://pypi.org/project/etabs-api/) while PyPI 
redirect the to it, it should still be fixed.