### PR TITLE
Fix dependency ( Sentry-SDK ) typo

### DIFF
--- a/ALLOWED_PYTHON_PACKAGES.txt
+++ b/ALLOWED_PYTHON_PACKAGES.txt
@@ -75,7 +75,7 @@ scikit-image
 scikit-learn
 scikit-sparse
 scipy
-sentry_sdk
+sentry-sdk
 shapely
 six
 streamdeck


### PR DESCRIPTION
`sentry_sdk` is actually [`sentry-sdk`](https://pypi.org/project/sentry-sdk/) while PyPI 
redirect the to it, it should still be fixed.