### PR TITLE
Add addon manager

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,6 +13,10 @@
     path = addFC
     url = https://github.com/GS90/addFC
     branch = main
+[submodule "AddonManager"]
+    path = AddonManager
+    url = https://github.com/FreeCAD/AddonManager
+    branch = main
 [submodule "AirPlaneDesign"]
     path = AirPlaneDesign
     url = https://github.com/FredsFactory/FreeCAD_AirPlaneDesign

--- a/AddonCatalog.json
+++ b/AddonCatalog.json
@@ -36,6 +36,15 @@
       "zip_url": "https://github.com/GS90/addFC/archive/refs/heads/main.zip"
     }
   ],
+  "AddonManager": [
+    {
+      "repository": "https://github.com/FreeCAD/AddonManager",
+      "git_ref": "main",
+      "branch_display_name": "main",
+      "zip_url": "https://github.com/FreeCAD/AddonManager/archive/refs/heads/main.zip",
+      "freecad_min": "0.20.1"
+    }
+  ],
   "AirPlaneDesign": [
     {
       "repository": "https://github.com/FredsFactory/FreeCAD_AirPlaneDesign",


### PR DESCRIPTION
This adds the Addon Manager as an addon itself, allowing it to self-update, and allowing older versions of FreeCAD (back to 0.20) to use the new Addon Manager, which supports additional addon types than the installed copy does, and will shortly provide a new user agent string to re-enable the wiki macro scraper.