### PR TITLE
Migrate ASM4 to backup mirror

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -51,7 +51,7 @@
     branch = master
 [submodule "Assembly4"]
     path = Assembly4
-    url = https://github.com/Zolko-123/FreeCAD_Assembly4
+    url = https://github.com/oursland/FreeCAD_Assembly4
     branch = master
 [submodule "Autoload"]
     path = Autoload

--- a/AddonCatalog.json
+++ b/AddonCatalog.json
@@ -111,10 +111,12 @@
   ],
   "Assembly4": [
     {
-      "repository": "https://github.com/Zolko-123/FreeCAD_Assembly4",
+      "repository": "https://github.com/oursland/FreeCAD_Assembly4",
       "git_ref": "master",
       "branch_display_name": "master",
-      "zip_url": "https://github.com/Zolko-123/FreeCAD_Assembly4/archive/refs/heads/master.zip"
+      "zip_url": "https://github.com/oursland/FreeCAD_Assembly4/archive/refs/heads/master.zip",
+      "freecad_max": "0.21.99",
+      "note": "Backup mirror of original Zolko-123 repository, no longer available on GitHub"
     }
   ],
   "Autoload": [


### PR DESCRIPTION
@oursland has spun up a backup mirror of the Assembly4 repo. It will probably require a modification to its package.xml before it works correctly with the Addon Manager.