### PR TITLE
Redirect Assembly4 to the new hosting while keeping the fork alive.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -51,7 +51,11 @@
     branch = master
 [submodule "Assembly4"]
     path = Assembly4
-    url = https://github.com/leoheck/FreeCAD_Assembly4
+    url = https://codeberg.org/Zolko/Assembly4
+    branch = main
+[submodule "Assembly4.1"]
+    path = Assembly4.1
+    url = https://github.com/leoheck/FreeCAD_Assembly4.1
     branch = main
 [submodule "Autoload"]
     path = Autoload

--- a/AddonCatalog.json
+++ b/AddonCatalog.json
@@ -111,11 +111,19 @@
   ],
   "Assembly4": [
     {
-      "repository": "https://github.com/leoheck/FreeCAD_Assembly4",
+      "repository": "https://codeberg.org/Zolko/Assembly4",
       "git_ref": "main",
       "branch_display_name": "main",
-      "zip_url": "https://github.com/leoheck/FreeCAD_Assembly4/archive/refs/heads/main.zip",
-      "note": "Backup mirror of the original Zolko-123 repository, which is no longer available on GitHub."
+      "zip_url": "https://codeberg.org/Zolko/Assembly4/archive/main.zip",
+      "note": "This is the original repository of Zolko's Assembly4."
+    }
+  "Assembly4.1": [
+    {
+      "repository": "https://github.com/leoheck/FreeCAD_Assembly4.1",
+      "git_ref": "main",
+      "branch_display_name": "main",
+      "zip_url": "https://github.com/leoheck/FreeCAD_Assembly4.1/archive/refs/heads/main.zip",
+      "note": "Community-friendly fork of the original Zolko's Assembly4 repository."
     }
   ],
   "Autoload": [


### PR DESCRIPTION
Hey @chennes, I am redirecting the Assembly4 once more after talking with Zolko.
He was able to set up a new repo for this workbench.

I am also keeping my fork alive now, having something that is community-driven for a while.

Please, check if the addition to the list makes sense. I just duplicated the section on the JSON. Should I add a submodule too? I could not find this info yet.