### PR TITLE
Energy Related Python Libs

### DIFF
--- a/ALLOWED_PYTHON_PACKAGES.txt
+++ b/ALLOWED_PYTHON_PACKAGES.txt
@@ -23,6 +23,7 @@
 PyOpenGL
 PyYAML
 aiofiles
+archaea
 asyncua
 atomicwrites
 autobahn
@@ -38,6 +39,7 @@ comtypes
 distro
 docutils
 eppy
+epw
 etabs-api
 ezdxf
 geomdl
@@ -46,6 +48,7 @@ gmsh-dev
 hausdorff
 idna
 ifcopenshell
+ifc2osmd
 ladybug-core
 ladybug-comfort
 ladybug-display
@@ -106,6 +109,7 @@ tzlocal
 urllib3
 vedo
 vermin
+voxcity
 wakatime-cli
 xgbxml
 xlrd


### PR DESCRIPTION
Add Energy related python libraries, as before but with new clean copy of ALLOWED_PYTHON_PACKAGES
to avoid merge conflict.

Libraries are
archaea
epw
ifc2osmd - Yes I know it has not been updated for a long time but it is starting point.
voxcity
