### PR TITLE
Remove incompatible options from allow-list

### DIFF
--- a/ALLOWED_PYTHON_PACKAGES.txt
+++ b/ALLOWED_PYTHON_PACKAGES.txt
@@ -32,20 +32,16 @@ beautifulsoup4
 blinker
 capytaine
 certifi
-certify
 charset-normalizer
 comtypes
 distro
 docutils
-eppy
 etabs-api
 ezdxf
 geomdl
 gmsh
-gmsh-dev
 hausdorff
 idna
-ifcopenshell
 ladybug-core
 ladybug-comfort
 ladybug-display
@@ -74,7 +70,6 @@ posthog
 protobuf
 py-slvs
 pycollada
-pydocx
 pyg4ometry
 pygit2
 pyjwt
@@ -106,7 +101,6 @@ tzlocal
 urllib3
 vedo
 vermin
-wakatime-cli
 xgbxml
 xlrd
 xlutils


### PR DESCRIPTION
* `certify` -- probably added by mistake as a mis-spelling of `certifi`
* `eppy` -- no known addon depends on it, depends on `pydot3k` which is sdist-only and we prefer to avoid
* `gmsh-dev` -- isn't on PyPI at all, it's on https://gmsh.info/python-packages-dev -- again, a situation we prefer to avoid
* `ifcopenshell` -- now included with FreeCAD, and versions that don't include it will almost certainly conflict
* `pydocx` -- very old, unsupported on modern Python (< 3.4)
* `wakatime-cli` -- just a wrapper that downloads an executable, not really appropriate for this list