### PR TITLE
[ - ] WakaTime-CLI

### DIFF
--- a/ALLOWED_PYTHON_PACKAGES.txt
+++ b/ALLOWED_PYTHON_PACKAGES.txt
@@ -106,7 +106,6 @@ tzlocal
 urllib3
 vedo
 vermin
-wakatime-cli
 xgbxml
 xlrd
 xlutils


### PR DESCRIPTION
Removed the `wakatime-cli` dependency from the allowed packages 
list as the only [user] I could find already doesn't depend on it anymore.

[user]: https://github.com/Pegoku/FreeCAD-WakaTime