### PR TITLE
Add freecad_min for the CADBaseLibrary WB

### DIFF
--- a/AddonCatalog.json
+++ b/AddonCatalog.json
@@ -227,6 +227,7 @@
       "repository": "https://github.com/mnnxp/cadbaselibrary-freecad",
       "git_ref": "master",
       "branch_display_name": "master",
+      "freecad_min": "0.21",
       "zip_url": "https://github.com/mnnxp/cadbaselibrary-freecad/archive/refs/heads/master.zip"
     }
   ],


### PR DESCRIPTION
Hi!  This is a PR request to add the minimum supported version 0.21 (freecad_min) to the AddonCatalog.json file for CADBase Library Workbench.  