### PR TITLE
Set max version for Better Tool library

### DIFF
--- a/AddonCatalog.json
+++ b/AddonCatalog.json
@@ -180,6 +180,7 @@
       "git_ref": "main",
       "branch_display_name": "main",
       "zip_url": "https://github.com/knipknap/better-tool-library/archive/refs/heads/main.zip"
+      "freecad_max": "1.0.99"
     }
   ],
   "BIMBots": [


### PR DESCRIPTION
BTL functionality mostly incorporated into the CAM workbench now.  BTL as an addon is incompatible