### PR TITLE
Improve featured button text

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@ are made available via FreeCAD's addon manager.
 
 <br/>
 
-[![Button Installation]][Installation]  
-[![Button Submission]][Submission]  
+[![Button Installation]][Installation]
+
+[![Button Submission]][Submission]
+
 [![Button Localization]][Localization]
 
 </div>
@@ -36,9 +38,9 @@ Bug reports and feature requests for addons should their respective repositories
 
 <!----------------------------------------------------------------------------->
 
-[Button Installation]: https://img.shields.io/badge/Installation-d45558?style=for-the-badge&logoColor=white&logo=actix
-[Button Localization]: https://img.shields.io/badge/Localization-ffaa00?style=for-the-badge&logoColor=white&logo=googletranslate
-[Button Submission]: https://img.shields.io/badge/Submission-3b8ad9?style=for-the-badge&logoColor=white&logo=testcafe
+[Button Installation]: https://img.shields.io/badge/Install_An_Addon-d45558?style=for-the-badge&logoColor=white&logo=actix
+[Button Localization]: https://img.shields.io/badge/Help_Localize_Addons-ffaa00?style=for-the-badge&logoColor=white&logo=googletranslate
+[Button Submission]: https://img.shields.io/badge/Submit_Your_Addon-3b8ad9?style=for-the-badge&logoColor=white&logo=testcafe
 
 [Addon Manager Source]: https://github.com/FreeCAD/AddonManager
 


### PR DESCRIPTION
Small adjustment to the text of the featured buttons.

In my conversation with Brad, I believe he said he
overlooked them because he didn't associate the words
by themselves to what he was looking for.

Disregarding that you have to scroll 
down a mile to even find the README ..

## Before
<img width="913" height="791" alt="image" src="https://github.com/user-attachments/assets/a22bd310-1d66-44ca-9e0e-f7c6d1f82c4c" />

## After
<img width="916" height="906" alt="image" src="https://github.com/user-attachments/assets/7db99f88-7e08-49e1-a864-fadb25936e83" />
