### PR TITLE
[ + ] Mesh To Body

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -377,6 +377,10 @@
     path = MeshRemodel
     url = https://github.com/mwganson/MeshRemodel
     branch = master
+[submodule "MeshToBody"]
+  path = MeshToBody
+  url = https://github.com/NSUBB/MeshToBody.git
+  branch = main
 [submodule "MnesarcoUtils"]
     path = MnesarcoUtils
     url = https://github.com/mnesarco/FreeCAD_Utils

--- a/AddonCatalog.json
+++ b/AddonCatalog.json
@@ -795,7 +795,8 @@
       "repository": "https://github.com/NSUBB/MeshToBody",
       "git_ref": "main",
       "branch_display_name": "main",
-      "zip_url": "https://github.com/NSUBB/MeshToBody/archive/refs/heads/main.zip"
+      "zip_url": "https://github.com/NSUBB/MeshToBody/archive/refs/heads/main.zip",
+      "freecad_min": "1.0.0"
     }
   ],
   "MnesarcoUtils": [

--- a/AddonCatalog.json
+++ b/AddonCatalog.json
@@ -790,6 +790,14 @@
       "zip_url": "https://github.com/mwganson/MeshRemodel/archive/refs/heads/master.zip"
     }
   ],
+  "MeshToBody": [
+    {
+      "repository": "https://github.com/NSUBB/MeshToBody",
+      "git_ref": "main",
+      "branch_display_name": "main",
+      "zip_url": "https://github.com/NSUBB/MeshToBody/archive/refs/heads/main.zip"
+    }
+  ],
   "MnesarcoUtils": [
     {
       "repository": "https://github.com/mnesarco/FreeCAD_Utils",


### PR DESCRIPTION
### Summary
Adds the MeshToBody macro to the FreeCAD Addon Manager.

- Added entry to `.gitmodules` (branch = main).
- Added entry to `AddonCatalog.json` with repository, branch, and zip_url.

### Issue
Closes #487 

### Addon Description
MeshToBody converts meshes into PartDesign Bodies, with cleanup of intermediate objects for document hygiene.
