### PR TITLE
[ 🗘 ] Free2Ki - Zip Url

### DIFF
--- a/AddonCatalog.json
+++ b/AddonCatalog.json
@@ -620,7 +620,7 @@
       "repository": "https://github.com/30350n/free2ki",
       "git_ref": "freecad-addons",
       "branch_display_name": "freecad-addons",
-      "zip_url": "https://github.com/30350n/free2ki/archive/refs/heads/freecad-addons.zip"
+      "zip_url": "https://github.com/30350n/free2ki/releases/latest/download/free2ki.zip"
     }
   ],
   "FreeGrid": [


### PR DESCRIPTION
Github archive downloads do not include git submodules, so installing my addon via the zip_url has been broken until now. If switched to using the url to the latest release and using a standard file name (free2ki.zip) for the addon file attached to the release.

This should work, unless the addon catalog has a problem with 302 redirects.
