### PR TITLE
Changing the order of branches for Rocket Workbench

### DIFF
--- a/AddonCatalog.json
+++ b/AddonCatalog.json
@@ -1090,17 +1090,17 @@
   "Rocket": [
     {
       "repository": "https://github.com/davesrocketshop/Rocket",
-      "git_ref": "v3.3.0",
-      "branch_display_name": "Pre-1.0 Compatible",
-      "freecad_max": "0.21.99",
-      "zip_url": "https://github.com/davesrocketshop/Rocket/archive/refs/tags/v3.3.0.zip"
-    },
-    {
-      "repository": "https://github.com/davesrocketshop/Rocket",
       "git_ref": "master",
       "branch_display_name": "master",
       "freecad_min": "1.0.0",
       "zip_url": "https://github.com/davesrocketshop/Rocket/archive/refs/heads/master.zip"
+    },
+    {
+      "repository": "https://github.com/davesrocketshop/Rocket",
+      "git_ref": "v3.3.0",
+      "branch_display_name": "Pre-1.0 Compatible",
+      "freecad_max": "0.21.99",
+      "zip_url": "https://github.com/davesrocketshop/Rocket/archive/refs/tags/v3.3.0.zip"
     }
   ],
   "SaveAndRestore": [


### PR DESCRIPTION
For all other workbenches, "main" or "master" always comes first, which I think is convenient and should be the case for Rocket workbench as well.