### PR TITLE
[ 🗘 ] ModernUI - Limit to < 1.2.0

### DIFF
--- a/AddonCatalog.json
+++ b/AddonCatalog.json
@@ -806,7 +806,8 @@
       "repository": "https://github.com/HakanSeven12/Modern-UI",
       "git_ref": "master",
       "branch_display_name": "master",
-      "zip_url": "https://github.com/HakanSeven12/Modern-UI/archive/refs/heads/master.zip"
+      "zip_url": "https://github.com/HakanSeven12/Modern-UI/archive/refs/heads/master.zip",
+      "freecad_max": "1.1.99"
     }
   ],
   "MOOC": [


### PR DESCRIPTION
Hakan has told me the Ribbon addon replaces ModernUI and 
since it's codebase is incompatible ( PySide2 ) with `1.2.0` this 
will limit it to versions before that.