### PR TITLE
Change branch for AddonManager submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,7 +16,7 @@
 [submodule "AddonManager"]
     path = AddonManager
     url = https://github.com/FreeCAD/AddonManager
-    branch = main
+    branch = Qt5Py38Compatibility
 [submodule "AirPlaneDesign"]
     path = AirPlaneDesign
     url = https://github.com/FredsFactory/FreeCAD_AirPlaneDesign


### PR DESCRIPTION
For versions of the Addon Manager that still use the .gitmodules file, provide a dedicated backwards-compatibility branch.