### PR TITLE
[ + ] Auto Alias

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -665,3 +665,7 @@
 	path = yaml-workbench
 	url = https://github.com/Mambix/FreeCAD-yaml-workbench
     branch = master
+[submodule "AutoAlias"]
+    path = AutoAlias
+    url = https://github.com/FreeCADPraxis/AutoAlias.git
+    branch = main

--- a/AddonCatalog.json
+++ b/AddonCatalog.json
@@ -1405,13 +1405,15 @@
       "branch_display_name": "FreeCAD ≥ v1.0",
       "freecad_min": "1.0.0",
       "zip_url": "https://github.com/Mambix/FreeCAD-yaml-workbench/archive/refs/heads/master.zip"
-    },
-      {
-     "repository": "https://github.com/FreeCADPraxis/AutoAlias",
+    }
+  ],
+  "AutoAlias": [
+    {
+        "repository": "https://github.com/FreeCADPraxis/AutoAlias",
         "git_ref": "main",
         "branch_display_name": "FreeCAD ≥ v1.0",
         "freecad_min": "1.0.0",
         "zip_url": "https://github.com/FreeCADPraxis/AutoAlias/archive/refs/heads/main.zip"
-      }
+    }
   ]
 }

--- a/AddonCatalog.json
+++ b/AddonCatalog.json
@@ -1405,6 +1405,13 @@
       "branch_display_name": "FreeCAD ≥ v1.0",
       "freecad_min": "1.0.0",
       "zip_url": "https://github.com/Mambix/FreeCAD-yaml-workbench/archive/refs/heads/master.zip"
-    }
+    },
+      {
+     "repository": "https://github.com/FreeCADPraxis/AutoAlias",
+        "git_ref": "main",
+        "branch_display_name": "FreeCAD ≥ v1.0",
+        "freecad_min": "1.0.0",
+        "zip_url": "https://github.com/FreeCADPraxis/AutoAlias/archive/refs/heads/main.zip"
+      }
   ]
 }


### PR DESCRIPTION
## New Addon: AutoAlias

AutoAlias automatically creates spreadsheet aliases from parameter name cells.
Type a descriptive name in any cell and the addon assigns it as an alias
to the adjacent value cell.

### Addon Details
- **Repository:** https://github.com/FreeCADPraxis/AutoAlias
- **License:** MIT
- **FreeCAD minimum version:** 1.0.0
- **package.xml:** valid and tested
- **Icon:** SVG included

### What it does
- Adds two toolbar buttons to the Spreadsheet workbench
- "Create Alias Now" syncs aliases on demand
- "Auto Alias (On/Off)" enables automatic alias refresh on cell changes
- Handles name normalization (spaces, hyphens, umlauts)
- Resolves alias collisions with numeric suffixes

### Checklist
- [x] Repository is public
- [x] package.xml is present and valid
- [x] README.md renders without HTML
- [x] SVG icon included (< 10KB)
- [x] License file present
- [x] .gitmodules entry added
- [x] AddonCatalog.json entry added